### PR TITLE
Enable wildcard expansion for file list

### DIFF
--- a/Tasks/Code Analysis/task/codeanalysis.ps1
+++ b/Tasks/Code Analysis/task/codeanalysis.ps1
@@ -78,15 +78,24 @@ $xslFileTemplate = resolveXSLFileTemplate
 
 #Compile files to run analysis
 $fileList.Split(",") | foreach {
-    Write-Host "Include file: $buildDirectory.Trim()\$_.Trim()"
+    $files = @($_)
+
+    $IsWP = [System.Management.Automation.WildcardPattern]::ContainsWildcardCharacters($files)
+    if($IsWP) { 
+        $files = Get-ChildItem -path $buildDirectory $files | % { $_.Name }
+    }
+
+    $files | foreach {
+        Write-Host "Include file: $buildDirectory.Trim()\$_.Trim()"
 
 	$chkdll = CheckFileDirectory -path $buildDirectory.Trim()\$_.Trim()
 
 	if ($chkdll)
 	{
-		$dll = "/file:$buildDirectory.Trim()\$_.Trim() "
-		$allArgs += $dll 
+	    $dll = "/file:$buildDirectory.Trim()\$_.Trim() "
+	    $allArgs += $dll 
 	}
+    }
 }
 
 


### PR DESCRIPTION
This is my first attempt at making any serious goings with Powershell, and also VSTS extensions, so I have not managed to test this and have no idea how well it works (apart from the individual lines on the command line).

The idea is that if you have a bunch of DLL files that are similarly named (eg all of our project ones are Ledgerscope.{project}.dll then you can set the Files parameter to be Ledgerscope*.dll and it will expand out the list of files