### PR TITLE
Additional arguments for 7z program

### DIFF
--- a/Tasks/7z Archive/task/7zA.ps1
+++ b/Tasks/7z Archive/task/7zA.ps1
@@ -36,18 +36,17 @@ function Get7ZipExe()
 }
 
 function CreateZip($folderPath, $archivePath)
-{ 
-
-    $items = Get-ChildItem -Path $folderPath
-
-    foreach ($item in $items) 
-    {
-        if ($archiveformat -eq "7z") { sz a -r $additionalArguments $archivePath $item.FullName}
-
-        if ($archiveformat -eq "zip") { sz a -tzip -r $additionalArguments $archivePath $item.FullName}
+{
+    $Tokens =  [management.automation.psparser]::Tokenize($additionalArguments,[ref]$null) | ForEach-Object { $_.Content }
+ 
+    if ($archiveformat -eq "7z") { 
+        Write-Verbose "Arguments = a -r $Tokens $archivePath $folderPath" -Verbose
+        sz a -r $Tokens $archivePath $folderPath
     }
-     
-  
+    elseif ($archiveformat -eq "zip") { 
+        Write-Verbose "Arguments = a -tzip -r $Tokens $archivePath $folderPath" -Verbose
+        sz a -tzip -r $Tokens $archivePath $folderPath
+    }
 }
 
 function RemoveFolder($folder)

--- a/Tasks/7z Archive/task/7zA.ps1
+++ b/Tasks/7z Archive/task/7zA.ps1
@@ -3,7 +3,8 @@
     [String] [Parameter(Mandatory = $true)] $folder,
 	[String] [Parameter(Mandatory = $true)] $archive,
     [String] [Parameter(Mandatory = $true)] $archiveformat,
-    [String] $removeFolderAfterExtraction
+    [String] $removeFolderAfterExtraction,
+    [String] $additionalArguments
 )
 
 Write-Verbose "Entering script Extract.ps1"  -Verbose
@@ -41,9 +42,9 @@ function CreateZip($folderPath, $archivePath)
 
     foreach ($item in $items) 
     {
-        if ($archiveformat -eq "7z") { sz a -r $archivePath $item.FullName}
+        if ($archiveformat -eq "7z") { sz a -r $additionalArguments $archivePath $item.FullName}
 
-        if ($archiveformat -eq "zip") { sz a -tzip -r $archivePath $item.FullName}
+        if ($archiveformat -eq "zip") { sz a -tzip -r $additionalArguments $archivePath $item.FullName}
     }
      
   

--- a/Tasks/7z Archive/task/task.json
+++ b/Tasks/7z Archive/task/task.json
@@ -68,7 +68,7 @@
       "label": "7z additional arguments",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Additional arguments besides a -r (.7z) or a -tzip -r (.zip) passed to 7z.exe program"
+	  "helpMarkDown": "Additional arguments besides 'a -r' (.7z) or 'a -tzip -r' (.zip) passed to 7z.exe program",
       "groupName": "advanced"
     }  
   ],

--- a/Tasks/7z Archive/task/task.json
+++ b/Tasks/7z Archive/task/task.json
@@ -1,83 +1,74 @@
 {
-  "id": "650f1ab8-d1d0-4508-8e05-7527d345a46e",
-  "name": "7z",
-  "friendlyName": "7-Zip Archive",
-  "description": "Compress a folder using 7-Zip",
-  "helpMarkDown": "[More Information](https://github.com/TotalALM/VSTS-Tasks/blob/master/Tasks/7z%20Archive/README.md)",
-  "category": "Utility",
-  "visibility": [
-                "Build",
-                "Release"
-                ],  
-  "author": "Total ALM",
-  "version": {
-    "Major": 1,
-    "Minor": 4,
-    "Patch": 4
-  },
-  "demands": [
-  ],
-   "groups": [
-    {
-      "name": "advanced",
-      "displayName": "Advanced",
-      "isExpanded": false
-    }
-    ],
-	
-	"inputs": [
-	{
-      "name": "Folder",
-      "type": "filePath",
-      "label": "Folder to Archive",
-      "defaultValue": "",
-	    "helpMarkDown": "The folder that you want to compress into a archive file.",
-      "required": true
-	 },
-    {
-      "name": "Archive",
-      "type": "filePath",
-      "label": "Archive",
-      "defaultValue": "",
-      "required": true,
-      "helpMarkDown": "Archive File that will be created."
-    }   ,
-    { 
-       "name": "ArchiveFormat", 
-       "type": "pickList", 
-       "label": "Archive Format", 
-       "defaultValue": "", 
-       "required": true, 
-       "options": { 
-         "7z": "7z", 
-         "zip": "zip" 
-        }, 
-       "helpMarkDown": "Select the archive format." 
-     } ,
-      {
-      "name": "RemoveFolderAfterExtraction",
-      "type": "boolean",
-      "label": "Remove Folder After Archive",
-      "defaultValue": "false",
-      "required": false,
-      "helpMarkDown": "Use to remove the folder file after archival"
-    }  ,
-      {
-      "name": "7zArguments",
-      "type": "string",
-      "label": "7z additional arguments",
-      "defaultValue": "",
-      "required": false,
-	  "helpMarkDown": "Additional arguments besides 'a -r' (.7z) or 'a -tzip -r' (.zip) passed to 7z.exe program",
-      "groupName": "advanced"
-    }  
-  ],
-  "instanceNameFormat": "7z Archive: $(Archive)",
-  "execution": {
-    "Powershell": {
-      "target": "$(currentDirectory)\\7zA.ps1",
-      "argumentFormat": "",
-      "workingDirectory": "$(currentDirectory)"
-    }
-  }
+	"id": "650f1ab8-d1d0-4508-8e05-7527d345a46e",
+	"name": "7z",
+	"friendlyName": "7-Zip Archive",
+	"description": "Compress a folder using 7-Zip",
+	"helpMarkDown": "[More Information](https://github.com/TotalALM/VSTS-Tasks/blob/master/Tasks/7z%20Archive/README.md)",
+	"category": "Utility",
+	"visibility": [
+		"Build",
+		"Release"
+	],
+	"author": "Total ALM",
+	"version": {
+		"Major": 1,
+		"Minor": 4,
+		"Patch": 4
+	},
+	"demands": [],
+	"groups": [{
+		"name": "advanced",
+		"displayName": "Advanced",
+		"isExpanded": false
+	}],
+
+	"inputs": [{
+		"name": "Folder",
+		"type": "filePath",
+		"label": "Folder to Archive",
+		"defaultValue": "",
+		"helpMarkDown": "The folder that you want to compress into a archive file.",
+		"required": true
+	}, {
+		"name": "Archive",
+		"type": "filePath",
+		"label": "Archive",
+		"defaultValue": "",
+		"required": true,
+		"helpMarkDown": "Archive File that will be created."
+	}, {
+		"name": "ArchiveFormat",
+		"type": "pickList",
+		"label": "Archive Format",
+		"defaultValue": "",
+		"required": true,
+		"options": {
+			"7z": "7z",
+			"zip": "zip"
+		},
+		"helpMarkDown": "Select the archive format."
+	}, {
+		"name": "RemoveFolderAfterExtraction",
+		"type": "boolean",
+		"label": "Remove Folder After Archive",
+		"defaultValue": "false",
+		"required": false,
+		"helpMarkDown": "Use to remove the folder file after archival"
+	}, {
+		"name": "AdditionalArguments",
+		"type": "string",
+		"label": "7z.exe additional arguments",
+		"defaultValue": "",
+		"required": false,
+		"helpMarkDown": "Additional arguments besides 'a -r' (.7z) or 'a -tzip -r' (.zip) passed to 7z.exe program",
+		"groupName": "advanced"
+	}],
+	"instanceNameFormat": "7z Archive: $(Archive)",
+	"execution": {
+		"Powershell": {
+			"target": "$(currentDirectory)\\7zA.ps1",
+			"argumentFormat": "",
+			"workingDirectory": "$(currentDirectory)"
+		}
+	}
 }

--- a/Tasks/7z Archive/task/task.json
+++ b/Tasks/7z Archive/task/task.json
@@ -68,7 +68,7 @@
       "label": "7z additional arguments",
       "defaultValue": "",
       "required": false,
-      "helpMarkDown": "Additional arguments besides 'a -r' (.7z) or 'a -tzip -r' (.zip) passed to 7z.exe program"
+      "helpMarkDown": "Additional arguments besides a -r (.7z) or a -tzip -r (.zip) passed to 7z.exe program"
       "groupName": "advanced"
     }  
   ],

--- a/Tasks/7z Archive/task/task.json
+++ b/Tasks/7z Archive/task/task.json
@@ -61,6 +61,15 @@
       "defaultValue": "false",
       "required": false,
       "helpMarkDown": "Use to remove the folder file after archival"
+    }  ,
+      {
+      "name": "7zArguments",
+      "type": "string",
+      "label": "7z additional arguments",
+      "defaultValue": "",
+      "required": false,
+      "helpMarkDown": "Additional arguments besides 'a -r' (.7z) or 'a -tzip -r' (.zip) passed to 7z.exe program"
+      "groupName": "advanced"
     }  
   ],
   "instanceNameFormat": "7z Archive: $(Archive)",


### PR DESCRIPTION
New advanced parameter to send additional switch to 7z program.
Changed CreateZip function deleting not useful foreach block.
7z documentation:

Examples
7z a archive1.zip subdir\

adds all files and subfolders from folder subdir to archive archive1.zip. The filenames in archive will contain subdir\ prefix.

7z a archive2.zip .\subdir\*

adds all files and subfolders from folder subdir to archive archive2.zip. The filenames in archive will not contain subdir\ prefix.



