### PR TITLE
Added SyncAfterTransfer paramater

### DIFF
--- a/Tasks/Delta File Copy/task/task.json
+++ b/Tasks/Delta File Copy/task/task.json
@@ -42,6 +42,14 @@
       "required": true,
       "helpMarkDown": "Target directory to copy files into."
     },
+     {
+      "name": "SyncAfterCopy",
+      "type": "boolean",
+      "label": "Sync after copy?",
+      "defaultValue": "",
+      "required": true,
+      "helpMarkDown": "Delete files from target directory if they don't exist in the source directory."
+    },
     {
       "name": "ExcludedFileNamesCommaDelimited",
       "type": "string",


### PR DESCRIPTION
If SyncAfterTransfer is set to true, any files in the target directory that did not exist in the source directory as deleted. This allows for a complete syncronization of files between source and target directory.