### PR TITLE
Permit underscores in token names

### DIFF
--- a/Tasks/Tokenization/task/tokenization.ps1
+++ b/Tasks/Tokenization/task/tokenization.ps1
@@ -9,7 +9,7 @@ param
 )
 
 $patterns = @()
-$regex = $TokenStart + '[A-Za-z0-9.]*' + $TokenEnd
+$regex = $TokenStart + '([A-Za-z0-9.]*|_)*' + $TokenEnd
 $matches = @()
 
 Write-Host (Get-LocalizedString -Key 'Regex: {0}...' -ArgumentList $regex)


### PR DESCRIPTION
This minor update changes the regex to include single underscores in token names